### PR TITLE
Fix Quest Logging Logic

### DIFF
--- a/frontend/daily/DailyQuestUi.cs
+++ b/frontend/daily/DailyQuestUi.cs
@@ -66,7 +66,6 @@ public partial class DailyQuestUi : Control
     private void OnBackToHomeButtonPressed()
     {
         DisconnectSignals();
-        new QuestLogManager().SaveQuestLog(_questManager.GetQuests().Values.ToList());
         GetTree().ChangeSceneToFile("res://shared/home.tscn");
     }
 

--- a/frontend/daily/QuestEditor.cs
+++ b/frontend/daily/QuestEditor.cs
@@ -47,6 +47,7 @@ public partial class QuestEditor : Control
         _questManager.Submit(_titleInput.Text, _descriptionInput.Text);
         _titleInput.Clear();
         _descriptionInput.Clear();
+        new QuestLogManager().SaveQuestLog(_questManager.GetQuests().Values.ToList());
     }
 
     private void OnManagerQuestAdded(int id)
@@ -93,7 +94,6 @@ public partial class QuestEditor : Control
     private void OnBackPressed()
     {
         DisconnectSignals();
-        new QuestLogManager().SaveQuestLog(_questManager.GetQuests().Values.ToList());
         QueueFree();
     }
 

--- a/frontend/daily/QuestManager.cs
+++ b/frontend/daily/QuestManager.cs
@@ -26,7 +26,7 @@ public partial class QuestManager : Node
     public void Submit(string title, string description)
     {
         Quest q = new Quest(title, description);
-        this._quests.Add(q.Id, q);
+        this._quests[q.Id] = q;
         EmitSignal("ManagerQuestAdded", q.Id);
     }
 

--- a/frontend/daily/components/CompletableQuestComponent.cs
+++ b/frontend/daily/components/CompletableQuestComponent.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using System.Linq;
 
 public partial class CompletableQuestComponent : HBoxContainer
 {
@@ -19,6 +20,7 @@ public partial class CompletableQuestComponent : HBoxContainer
     private void CheckboxOnToggled(bool toggledOn)
     {
         _questManager.ToggleCompletion(_quest.Id);
+        new QuestLogManager().SaveQuestLog(_questManager.GetQuests().Values.ToList());
     }
 
     public void Initialize(Quest quest)

--- a/frontend/daily/components/EditableQuestComponent.cs
+++ b/frontend/daily/components/EditableQuestComponent.cs
@@ -1,5 +1,6 @@
 using Godot;
 using System;
+using System.Linq;
 
 public partial class EditableQuestComponent : HBoxContainer
 {
@@ -21,12 +22,14 @@ public partial class EditableQuestComponent : HBoxContainer
     private void DeleteButtonOnPressed()
     {
         _questManager.Remove(_quest.Id);
+        new QuestLogManager().SaveQuestLog(_questManager.GetQuests().Values.ToList());
     }
 
     private void SaveButtonOnPressed()
     {
         // Update(_title.Text, _description.Text);
         _questManager.Edit(_quest.Id, _title.Text, _description.Text);
+        new QuestLogManager().SaveQuestLog(_questManager.GetQuests().Values.ToList());
     }
 
     public void Initialize(Quest quest)


### PR DESCRIPTION
Previously, quests are logged when pressing button to switch pages, but doesn't account for quitting game. Now, quests are logged when quests are updated.