### PR TITLE
Make tweaks to attack system

### DIFF
--- a/frontend/active/characters/DamageSystem/HealthComponent.cs
+++ b/frontend/active/characters/DamageSystem/HealthComponent.cs
@@ -21,13 +21,10 @@ namespace nuscutiesapp.active.characters.DamageSystem
             if (CurrentHP <= 0) return;
             CurrentHP -= damageInfo.Amount;
 
+            Damaged?.Invoke(CurrentHP, damageInfo);
             if (CurrentHP <= 0)
             {
                 Died?.Invoke(damageInfo);
-            }
-            else
-            {
-                Damaged?.Invoke(CurrentHP, damageInfo);
             }
         }
     }

--- a/frontend/active/characters/enemy.tscn
+++ b/frontend/active/characters/enemy.tscn
@@ -205,6 +205,8 @@ libraries = {
 }
 
 [node name="NavigationAgent2D" type="NavigationAgent2D" parent="." index="3"]
+target_desired_distance = 5.0
+debug_enabled = true
 
 [node name="Health" parent="." index="4"]
 MaxHP = 50.0


### PR DESCRIPTION
Closes #80 

The Damaged event is now invoked immediately after applying damage, regardless of whether the entity dies. This is for more feedback to the user. Also updated enemy.tscn to set NavigationAgent2D's target_desired_distance to 5.0 so that the enemy will go close enough to attack the player.

Further implementation can include strategies to handle weapon use and reload logic (optionally with a state system), as well as strategies to determine triggers for weapon use by a character (e.g. click or proximity or automatic)