### PR TITLE
Add coins to daily quests + passive dungeons

### DIFF
--- a/frontend/daily/components/CompletableQuestComponent.cs
+++ b/frontend/daily/components/CompletableQuestComponent.cs
@@ -1,4 +1,5 @@
 using Godot;
+using nuscutiesapp.tools;
 using System;
 using System.Linq;
 
@@ -15,11 +16,13 @@ public partial class CompletableQuestComponent : HBoxContainer
     private Quest _quest; // TODO: only id needed, quest manager takes care of the quest storing
     private QuestManager _questManager;
     private ProgressionManager _expManager;
+    private PlayerInventoryManager _inventoryManager;
 
     public override void _Ready()
     {
         _questManager = GetNode<QuestManager>("/root/QuestManager");
         _expManager = GetNode<ProgressionManager>("/root/ProgressionManager");
+        _inventoryManager = GetNode<PlayerInventoryManager>("/root/PlayerInventoryManager");
         _checkbox.Toggled += CheckboxOnToggled;
         _editButton.Pressed += OnEditButtonPressed;
     }
@@ -30,10 +33,23 @@ public partial class CompletableQuestComponent : HBoxContainer
         if (toggledOn)
         {
             _expManager.AddExp(100);
+            int coinReward = _inventoryManager.CalculateDailyQuestCoinReward();
+            _inventoryManager.AddCoins(coinReward);
+            GD.Print($"Daily quest completed! Gained {coinReward} coins");
         }
         else
         {
             _expManager.AddExp(-100);
+            int coinPenalty = _inventoryManager.CalculateDailyQuestCoinReward();
+            bool success = _inventoryManager.SpendCoins(coinPenalty);
+            if (success)
+            {
+                GD.Print($"Daily quest uncompleted! Lost {coinPenalty} coins");
+            }
+            else
+            {
+                GD.Print($"Daily quest uncompleted! Not enough coins to deduct {coinPenalty}");
+            }
         }
         new QuestLogManager().SaveQuestLog(_questManager.GetQuests().Values.ToList());
     }

--- a/frontend/passive/PassiveEndScene.cs
+++ b/frontend/passive/PassiveEndScene.cs
@@ -7,6 +7,9 @@ public partial class PassiveEndScene : Node
     private Label _expAccumulatedLabel;
 
     [Export]
+    private Label _coinsAccumulatedLabel;
+
+    [Export]
     private Label _totalTimeSpentLabel;
 
     [Export]
@@ -14,15 +17,25 @@ public partial class PassiveEndScene : Node
 
     private PassiveSessionInfoManager _passiveSessionInfoManager;
     private ProgressionManager _expManager;
+    private PlayerInventoryManager _inventoryManager;
 
     public override void _Ready()
     {
         this._passiveSessionInfoManager = this.GetNode<PassiveSessionInfoManager>("/root/PassiveSessionInfoManager");
         this._expManager = this.GetNode<ProgressionManager>("/root/ProgressionManager");
+        this._inventoryManager = this.GetNode<PlayerInventoryManager>("/root/PlayerInventoryManager");
+
         int expGained = _passiveSessionInfoManager.getAccumulatedExp();
+        int coinsGained = _passiveSessionInfoManager.getAccumulatedCoins();
+
         _expManager.AddExp(expGained);
+        _inventoryManager.AddCoins(coinsGained);
 
         this._expAccumulatedLabel.Text = $"Total EXP Gained: {expGained}";
+        if (_coinsAccumulatedLabel != null)
+        {
+            this._coinsAccumulatedLabel.Text = $"Total Coins Gained: {coinsGained}";
+        }
         this._totalTimeSpentLabel.Text = $"Total Time Spent: {_passiveSessionInfoManager.getTimeSpent():F0} seconds";
 
         this._returnButton.Pressed += () => this.GetTree().ChangeSceneToFile(Paths.Passive);

--- a/frontend/passive/PassiveOngoing.cs
+++ b/frontend/passive/PassiveOngoing.cs
@@ -7,20 +7,28 @@ public partial class PassiveOngoing : Control
     [Export] Label _totalTimeLabel;
     [Export] ProgressBar _timeProgressBar;
     [Export] Label _expAccumulatedLabel;
+    [Export] Label _coinsAccumulatedLabel;
     [Export] Button _quitButton;
 
     private double _totalTime;
     private double _timeSpent = 0;
     private int _expAccumulated = 0;
+    private int _coinsAccumulated = 0;
     private PassiveSessionInfoManager _passiveSessionInfoManager;
+    private PlayerInventoryManager _inventoryManager;
 
     public override void _Ready()
     {
         _passiveSessionInfoManager = this.GetNode<PassiveSessionInfoManager>("/root/PassiveSessionInfoManager");
+        _inventoryManager = this.GetNode<PlayerInventoryManager>("/root/PlayerInventoryManager");
         this._totalTime = _passiveSessionInfoManager.getTotalTime();
         _timeSpentLabel.Text = _timeSpent.ToString("F0");
         _totalTimeLabel.Text = $"out of {_totalTime:F0} seconds";
         _expAccumulatedLabel.Text = $"{_expAccumulated:F0} EXP";
+        if (_coinsAccumulatedLabel != null)
+        {
+            _coinsAccumulatedLabel.Text = $"{_coinsAccumulated:F0} Coins";
+        }
 
         _quitButton.Pressed += () => OnEnd("Quit");
     }
@@ -34,6 +42,12 @@ public partial class PassiveOngoing : Control
         _expAccumulated = (int)_timeSpent / 2 * 100;
         _expAccumulatedLabel.Text = $"{_expAccumulated:F0} EXP";
 
+        _coinsAccumulated = _inventoryManager.CalculatePassiveDungeonCoinReward(_timeSpent / 60.0);
+        if (_coinsAccumulatedLabel != null)
+        {
+            _coinsAccumulatedLabel.Text = $"{_coinsAccumulated:F0} Coins";
+        }
+
         if (_timeSpent >= _totalTime)
         {
             OnEnd("Finished");
@@ -44,6 +58,7 @@ public partial class PassiveOngoing : Control
     {
         _passiveSessionInfoManager.setTimeSpent(this._timeSpent);
         _passiveSessionInfoManager.setAccumulatedExp(this._expAccumulated);
+        _passiveSessionInfoManager.setAccumulatedCoins(this._coinsAccumulated);
         this.GetTree().ChangeSceneToFile(Paths.PassiveEndScene);
     }
 }

--- a/frontend/passive/tools/PassiveSessionInfoManager.cs
+++ b/frontend/passive/tools/PassiveSessionInfoManager.cs
@@ -5,6 +5,7 @@ public partial class PassiveSessionInfoManager : Node
     private double _totalTime;
     private double _timeSpent;
     private int _accumulatedExp;
+    private int _accumulatedCoins;
 
     public void setTotalTime(double totalTime)
     {
@@ -34,5 +35,15 @@ public partial class PassiveSessionInfoManager : Node
     public int getAccumulatedExp()
     {
         return _accumulatedExp;
+    }
+
+    public void setAccumulatedCoins(int accumulatedCoins)
+    {
+        _accumulatedCoins = accumulatedCoins;
+    }
+
+    public int getAccumulatedCoins()
+    {
+        return _accumulatedCoins;
     }
 }

--- a/frontend/tools/PlayerInventoryManager.cs
+++ b/frontend/tools/PlayerInventoryManager.cs
@@ -1,4 +1,5 @@
 using Godot;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -6,10 +7,13 @@ namespace nuscutiesapp.tools
 {
     public partial class PlayerInventoryManager : BaseStatManager<PlayerInventoryData>
     {
+        private ProgressionManager _progressionManager;
+
         public override void _Ready()
         {
             GD.Print(OS.GetUserDataDir());
             base._Ready();
+            _progressionManager = GetNode<ProgressionManager>("/root/ProgressionManager");
         }
 
         [Signal]
@@ -27,6 +31,43 @@ namespace nuscutiesapp.tools
 
         protected override void OnDataChanged()
         {
+        }
+
+        public int CalculateDailyQuestCoinReward()
+        {
+            int level = _progressionManager.GetLevel();
+            int baseCoinReward = 50;
+            double scaleFactor = 1.15;
+
+            int reward = (int)(baseCoinReward * Math.Pow(scaleFactor, level - 1));
+            return Math.Max(reward, baseCoinReward);
+        }
+
+        public int CalculatePassiveDungeonCoinReward(double timeSpentMinutes)
+        {
+            int level = _progressionManager.GetLevel();
+            double baseCoinRate = 5.0;
+            double levelMultiplier = 1.0 + (level * 0.1);
+            double exponentialMultiplier = Math.Pow(timeSpentMinutes, 1.2);
+
+            Random random = new Random();
+            double variance = 0.85 + (random.NextDouble() * 0.3);
+
+            int coins = (int)(baseCoinRate * levelMultiplier * exponentialMultiplier * variance);
+            return Math.Max(coins, 1);
+        }
+
+        public int CalculateActiveDungeonEnemyCoinReward()
+        {
+            int level = _progressionManager.GetLevel();
+            int baseCoinReward = 15;
+            double scaleFactor = 1.12;
+
+            Random random = new Random();
+            double variance = 0.8 + (random.NextDouble() * 0.4);
+
+            int reward = (int)(baseCoinReward * Math.Pow(scaleFactor, level - 1) * variance);
+            return Math.Max(reward, baseCoinReward);
         }
 
         public bool AddCoins(int amount)


### PR DESCRIPTION
Implemented coin reward logic for daily quest completion and passive dungeon sessions. Updated UI to display accumulated coins, and extended PlayerInventoryManager with coin calculation methods based on player level and session duration. PassiveSessionInfoManager now tracks accumulated coins.