### PR TITLE
Add ColorManager for unified character color effects

### DIFF
--- a/frontend/active/characters/Character.cs
+++ b/frontend/active/characters/Character.cs
@@ -1,4 +1,5 @@
 using Godot;
+using nuscutiesapp.active.characters;
 using nuscutiesapp.active.characters.ActivateWeaponStrategies;
 using nuscutiesapp.active.characters.DamageSystem;
 using nuscutiesapp.active.characters.MovementStrategies;
@@ -30,6 +31,7 @@ public abstract partial class Character : CharacterBody2D
 
     public HealthComponent Health;
     public StatusEffectManager StatusEffects;
+    public ColorManager MyColorManager;
 
     private ActiveDungeonEventManager _eventManager;
     private BaseNumberManager _numberManager;
@@ -44,6 +46,7 @@ public abstract partial class Character : CharacterBody2D
         this.MyAnimationPlayer = GetNode<AnimationPlayer>("AnimationPlayer");
         this.Health = GetNode<HealthComponent>("Health");
         this.StatusEffects = GetNode<StatusEffectManager>("StatusEffectManager");
+        this.MyColorManager = GetNode<ColorManager>("MyColorManager");
 
         Health.Damaged += OnDamaged;
         Health.Died += OnDied;

--- a/frontend/active/characters/ColorManager.cs
+++ b/frontend/active/characters/ColorManager.cs
@@ -1,0 +1,96 @@
+using Godot;
+using System;
+
+namespace nuscutiesapp.active.characters
+{
+    public partial class ColorManager : Node
+    {
+        [Export] private Character _parent;
+        [Export] private AnimatedSprite2D _sprite;
+
+        private Color _originalBaseColor = Colors.White;
+        private Color _currentBaseColor = Colors.White;
+        private Color _currentColor = Colors.White;
+
+        private bool _isPulsing = false;
+        private float _pulseTimer = 0f;
+        private float _pulseDuration = 0f;
+        private Color _pulseColor = Colors.White;
+
+        public override void _Ready()
+        {
+            if (_sprite != null)
+            {
+                _originalBaseColor = _sprite.Modulate;
+                _currentBaseColor = _originalBaseColor;
+                _currentColor = _originalBaseColor;
+            }
+        }
+
+        public void SetBaseColor(Color color)
+        {
+            _currentBaseColor = color;
+            if (!_isPulsing)
+            {
+                _currentColor = color;
+                ApplyColor();
+            }
+        }
+
+        public void Pulse(Color color, float duration)
+        {
+            _pulseColor = color;
+            _pulseDuration = duration;
+            _pulseTimer = duration;
+            _isPulsing = true;
+            _currentColor = color;
+            ApplyColor();
+        }
+
+        public void ResetToOriginal()
+        {
+            _currentBaseColor = _originalBaseColor;
+            _currentColor = _originalBaseColor;
+            _isPulsing = false;
+            ApplyColor();
+        }
+
+        public override void _Process(double delta)
+        {
+            if (_isPulsing)
+            {
+                _pulseTimer -= (float)delta;
+
+                if (_pulseTimer <= 0f)
+                {
+                    _isPulsing = false;
+                    _currentColor = _currentBaseColor;
+                    ApplyColor();
+                }
+            }
+        }
+
+        private void ApplyColor()
+        {
+            if (_sprite != null)
+            {
+                _sprite.Modulate = _currentColor;
+            }
+        }
+
+        public Color GetCurrentColor()
+        {
+            return _currentColor;
+        }
+
+        public Color GetBaseColor()
+        {
+            return _currentBaseColor;
+        }
+
+        public bool IsPulsing()
+        {
+            return _isPulsing;
+        }
+    }
+}

--- a/frontend/active/characters/DamageSystem/HealthComponent.cs
+++ b/frontend/active/characters/DamageSystem/HealthComponent.cs
@@ -15,7 +15,6 @@ namespace nuscutiesapp.active.characters.DamageSystem
         public event Action<DamageInfo> Died;
 
         protected DerivedStatCalculator _derivedStatCalculator;
-        private Color _originalModulation;
 
         public override void _Ready()
         {
@@ -71,19 +70,11 @@ namespace nuscutiesapp.active.characters.DamageSystem
             return false;
         }
 
-        private async void ApplyDamageModulation()
+        private void ApplyDamageModulation()
         {
-            if (_owner?.AnimatedSprite != null)
+            if (_owner?.MyColorManager != null)
             {
-                _originalModulation = _owner.AnimatedSprite.Modulate;
-                _owner.AnimatedSprite.Modulate = new Color(1, 0.5f, 0.5f);
-
-                await _owner.ToSignal(_owner.GetTree().CreateTimer(0.3f), SceneTreeTimer.SignalName.Timeout);
-
-                if (_owner?.AnimatedSprite != null)
-                {
-                    _owner.AnimatedSprite.Modulate = _originalModulation;
-                }
+                _owner.MyColorManager.Pulse(new Color(1, 0.5f, 0.5f), 0.3f);
             }
         }
     }

--- a/frontend/active/characters/StatusEffects/ModulationStrategy.cs
+++ b/frontend/active/characters/StatusEffects/ModulationStrategy.cs
@@ -5,30 +5,27 @@ namespace nuscutiesapp.active.characters.StatusEffects
     public class ModulationStrategy : IVisualEffectStrategy
     {
         private Color _modulationColor;
-        private Color _originalColor;
         private bool _isApplied = false;
 
         public ModulationStrategy(Color modulationColor)
         {
             _modulationColor = modulationColor;
-            _originalColor = new Color(1.0f, 1.0f, 1.0f);
         }
 
         public void ApplyEffect(Character target)
         {
-            if (target?.AnimatedSprite != null)
+            if (target?.MyColorManager != null)
             {
-                _originalColor = target.AnimatedSprite.Modulate;
-                target.AnimatedSprite.Modulate = _modulationColor;
+                target.MyColorManager.SetBaseColor(_modulationColor);
                 _isApplied = true;
             }
         }
 
         public void RemoveEffect(Character target)
         {
-            if (target?.AnimatedSprite != null)
+            if (target?.MyColorManager != null)
             {
-                target.AnimatedSprite.Modulate = _originalColor;
+                target.MyColorManager.ResetToOriginal();
                 _isApplied = false;
             }
         }

--- a/frontend/active/characters/character.tscn
+++ b/frontend/active/characters/character.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=3 format=3 uid="uid://c2aoax7gfqdq6"]
+[gd_scene load_steps=4 format=3 uid="uid://c2aoax7gfqdq6"]
 
-[ext_resource type="Script" uid="uid://g6fvaxfdi51w" path="res://active/characters/DamageSystem/HealthComponent.cs" id="1_kqxnq"]
-[ext_resource type="Script" path="res://active/characters/StatusEffects/StatusEffectManager.cs" id="2_status"]
+[ext_resource type="Script" uid="uid://exnmcafbjum7" path="res://active/characters/DamageSystem/HealthComponent.cs" id="1_kqxnq"]
+[ext_resource type="Script" uid="uid://dglm2f8hoivc0" path="res://active/characters/StatusEffects/StatusEffectManager.cs" id="2_status"]
+[ext_resource type="Script" uid="uid://cmqe1na585axl" path="res://active/characters/ColorManager.cs" id="3_color"]
 
 [node name="Character" type="CharacterBody2D"]
 
@@ -16,3 +17,6 @@ script = ExtResource("1_kqxnq")
 
 [node name="StatusEffectManager" type="Node" parent="."]
 script = ExtResource("2_status")
+
+[node name="MyColorManager" type="Node" parent="."]
+script = ExtResource("3_color")

--- a/frontend/active/characters/enemy.tscn
+++ b/frontend/active/characters/enemy.tscn
@@ -1,9 +1,9 @@
 [gd_scene load_steps=19 format=3 uid="uid://dmweiqk1jxob0"]
 
 [ext_resource type="PackedScene" uid="uid://c2aoax7gfqdq6" path="res://active/characters/character.tscn" id="1_8ah4a"]
-[ext_resource type="Script" uid="uid://dpd1rukgyw4s5" path="res://active/characters/Enemy.cs" id="2_htnh5"]
-[ext_resource type="Texture2D" uid="uid://bx5xnbjp5m747" path="res://assets/dungeon_art/enemies/flying creature/fly_anim_spritesheet.png" id="3_1prlo"]
-[ext_resource type="Texture2D" uid="uid://clk2gv5lxpvoe" path="res://assets/dungeon_art/effects (new)/enemy_afterdead_explosion_anim_spritesheet.png" id="3_ywsfq"]
+[ext_resource type="Script" uid="uid://cphd6v7omnk8g" path="res://active/characters/Enemy.cs" id="2_htnh5"]
+[ext_resource type="Texture2D" uid="uid://diuss3xwmft2q" path="res://assets/dungeon_art/enemies/flying creature/fly_anim_spritesheet.png" id="3_1prlo"]
+[ext_resource type="Texture2D" uid="uid://bnimnlhqqighc" path="res://assets/dungeon_art/effects (new)/enemy_afterdead_explosion_anim_spritesheet.png" id="3_ywsfq"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_mff4r"]
 atlas = ExtResource("3_ywsfq")
@@ -209,3 +209,7 @@ radius = 5.0
 
 [node name="Health" parent="." index="4"]
 MaxHP = 50.0
+
+[node name="MyColorManager" parent="." index="6" node_paths=PackedStringArray("_parent", "_sprite")]
+_parent = NodePath("..")
+_sprite = NodePath("../AnimatedSprite2D")

--- a/frontend/active/characters/player.tscn
+++ b/frontend/active/characters/player.tscn
@@ -1,12 +1,12 @@
 [gd_scene load_steps=31 format=3 uid="uid://d4ukkagofjxm"]
 
 [ext_resource type="PackedScene" uid="uid://c2aoax7gfqdq6" path="res://active/characters/character.tscn" id="1_wjgc2"]
-[ext_resource type="Texture2D" uid="uid://e44ds11llc6w" path="res://assets/dungeon_art/heroes/knight/knight_idle_spritesheet.png" id="2_tlgbr"]
-[ext_resource type="Script" uid="uid://dxgw4m3bmqjax" path="res://active/characters/Player.cs" id="2_x55qg"]
-[ext_resource type="Texture2D" uid="uid://clk2gv5lxpvoe" path="res://assets/dungeon_art/effects (new)/enemy_afterdead_explosion_anim_spritesheet.png" id="3_guxn7"]
-[ext_resource type="Texture2D" uid="uid://bw21rbqmofoji" path="res://assets/dungeon_art/heroes/knight/knight_run_spritesheet.png" id="3_x55qg"]
+[ext_resource type="Texture2D" uid="uid://jkklqrkxx82h" path="res://assets/dungeon_art/heroes/knight/knight_idle_spritesheet.png" id="2_tlgbr"]
+[ext_resource type="Script" uid="uid://if4go2den0bl" path="res://active/characters/Player.cs" id="2_x55qg"]
+[ext_resource type="Texture2D" uid="uid://bnimnlhqqighc" path="res://assets/dungeon_art/effects (new)/enemy_afterdead_explosion_anim_spritesheet.png" id="3_guxn7"]
+[ext_resource type="Texture2D" uid="uid://cy6y8rl2q5ip0" path="res://assets/dungeon_art/heroes/knight/knight_run_spritesheet.png" id="3_x55qg"]
 [ext_resource type="PackedScene" uid="uid://b021spcuxd3gw" path="res://active/direction_arrow.tscn" id="7_e5a7i"]
-[ext_resource type="Script" uid="uid://3x37o78ldiak" path="res://active/characters/DamageSystem/PlayerHealthComponent.cs" id="7_s54qp"]
+[ext_resource type="Script" uid="uid://l76kk6wlbomj" path="res://active/characters/DamageSystem/PlayerHealthComponent.cs" id="7_s54qp"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0y68l"]
 atlas = ExtResource("3_guxn7")
@@ -278,3 +278,7 @@ script = ExtResource("7_s54qp")
 MaxHP = 60.0
 
 [node name="DirectionArrow" parent="." index="4" instance=ExtResource("7_e5a7i")]
+
+[node name="MyColorManager" parent="." index="6" node_paths=PackedStringArray("_parent", "_sprite")]
+_parent = NodePath("..")
+_sprite = NodePath("../AnimatedSprite2D")


### PR DESCRIPTION
Introduces a ColorManager component to handle color modulation and pulsing effects for characters. Updates HealthComponent and ModulationStrategy to use ColorManager instead of directly modifying AnimatedSprite2D. Scene files are updated to include the new MyColorManager node for both player and enemy characters, improving modularity and maintainability of visual effects.